### PR TITLE
white background fix

### DIFF
--- a/src/components/style.css
+++ b/src/components/style.css
@@ -7,6 +7,7 @@
 
 .container {
   z-index: 10;
+  background-color: white;
 }
 
 .content-card {


### PR DESCRIPTION
fixes #1346 

Adds a white background to blog post content to avoid overlapping between the sidebar and blog content