### PR TITLE
Fix broken link of Architecture eBook cover img

### DIFF
--- a/src/pages/architecture-ebook/index.md
+++ b/src/pages/architecture-ebook/index.md
@@ -6,7 +6,7 @@ image: /img/whiteboard.jpg
 ---
 # Architecture eBook
 
-[![Architecture-eBook-Cover](/img/Architecture-eBook-Cover-242x300.png)]([/img/Architecture-eBook-Cover.png](https://www.microsoft.com/net/download/thank-you/aspnet-ebook))
+[![Architecture-eBook-Cover](/img/Architecture-eBook-Cover-242x300.png)](https://www.microsoft.com/net/download/thank-you/aspnet-ebook)
 
 I've written an eBook for Microsoft titled [Architecting Modern Web Applications with ASP.NET Core and Microsoft Azure](https://www.microsoft.com/net/download/thank-you/aspnet-ebook). It's part of the [.NET Application Architecture guidance portal](https://www.microsoft.com/net/learn/architecture) on Microsoft.com. The book also includes a sample reference online store application that demonstrates (in a very simple app) some of the principles and patterns described. This book intentionally focuses on a monolithic architecture, meaning that the application is deployed as a single unit. There's [an accompanying ebook by Cesar de la Torre](https://www.microsoft.com/net/download/thank-you/microservices-architecture-ebook) that covers building a microservices and containers-based architecture that uses the same online store sample, but built in a different way. Most customers will find the single-deployment approach to be less expensive to create, deploy, and maintain, but the microservices approach is certainly worthwhile for certain high-end applications.
 


### PR DESCRIPTION
This PR fixes a broken link behind the Architecture eBook cover image on the Ardalis website.

The href of the link in MarkDown to the Microsoft website was incorrect and the link has now been fixed.  

No documentation changes are required after this merge.