### PR TITLE
Fixing a couple null descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,3 +112,25 @@ $ npm run serve
 ## Purgecss
 
 This plugin uses [gatsby-plugin-purgecss](https://www.gatsbyjs.org/packages/gatsby-plugin-purgecss/) and [bulma](https://bulma.io/). The bulma builds are usually ~170K but reduced 90% by purgecss.
+
+## Finding Empty Descriptions
+
+This query can be used to help with fidning empty description fields on the site. This is important for both the OpenGraph preview as well as SEO.
+
+```graphql
+    {
+          site {
+            siteMetadata {
+              siteUrl
+            }
+          }
+          allMarkdownRemark(filter: {frontmatter: {description: {eq:null}}}) {
+            nodes {
+              frontmatter {
+                title
+                description
+              }
+            }
+          }  
+        }
+    ```

--- a/src/pages/blog/add-https-to-any-site-for-free.md
+++ b/src/pages/blog/add-https-to-any-site-for-free.md
@@ -5,6 +5,7 @@ path: /add-https-to-any-site-for-free
 date: 2019-03-06
 featuredpost: false
 featuredimage: /img/cloudflare-addsite-760x360.png
+description: Add HTTPS to any site for free using Cloudflare.
 tags:
   - dns
   - https

--- a/src/pages/blog/git-graph-visualizes-branches-in-vs-code-for-free.md
+++ b/src/pages/blog/git-graph-visualizes-branches-in-vs-code-for-free.md
@@ -1,6 +1,7 @@
 ---
 templateKey: blog-post
 title: Git Graph Visualizes Branches in VS Code for Free
+description: Git Graph does just what I want, which is to visualize commits to my git repository in a graph format that lets me easily see which commits and branches are where relative to one another.
 date: 2019-09-04
 path: /git-graph-visualizes-branches-in-vs-code-for-free
 featuredpost: false


### PR DESCRIPTION
Closes #1659

Also fixes the description for an article queued on 11/5

Also captures the query for all pages on the site that don't have descriptions - didn't want to lose that query that's documented in the issue.